### PR TITLE
update upload outputs to match query outputs

### DIFF
--- a/cmd/github.go
+++ b/cmd/github.go
@@ -72,8 +72,12 @@ func uploadBlob(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to upload to GitHub storage: %w", err)
 	}
 	ghlog.Logger.Info("Uploaded archive to GitHub storage successfully")
-	ghlog.Logger.Info("ID: " + uploadArchiveResponse.NodeID)
-	ghlog.Logger.Info("URL: " + uploadArchiveResponse.URI)
+	ghlog.Logger.Info("Blob ID: " + uploadArchiveResponse.NodeID)
+	ghlog.Logger.Info("Blob GUID: " + uploadArchiveResponse.GUID)
+	ghlog.Logger.Info("Blob Name: " + uploadArchiveResponse.Name)
+	ghlog.Logger.Info("Blob Size: " + fmt.Sprintf("%d", uploadArchiveResponse.Size))
+	ghlog.Logger.Info("Blob URI: " + uploadArchiveResponse.URI)
+	ghlog.Logger.Info("Blob Created At: " + uploadArchiveResponse.CreatedAt)
 
 	return nil
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -427,16 +427,11 @@ func multipartUpload(ctx context.Context, orgId string, reader io.ReadSeeker, si
 
 	var uploadArchiveResponse UploadArchiveResponse
 
+	// unmarshal the response
 	if err := json.Unmarshal(body, &uploadArchiveResponse); err != nil {
+		ghlog.Logger.Error("Failed to decode response", zap.Error(err))
 		return nil, fmt.Errorf("failed to decode response: %v", err)
 	}
-
-	uploadArchiveResponse.URI = fmt.Sprintf("gei://archive/%s", guid)
-	uploadArchiveResponse.GUID = guid
-	uploadArchiveResponse.NodeID = "Not available"
-	uploadArchiveResponse.Name = blobName
-	uploadArchiveResponse.Size = int(size)
-	uploadArchiveResponse.CreatedAt = finalizeResp.Header.Get("Date")
 
 	return &uploadArchiveResponse, nil
 }


### PR DESCRIPTION
The response of the multipart upload has changed to include all the details included in the single part upload. Now we can show all the same details that we show when we query blobs after an upload.